### PR TITLE
debugEnabled defaults to true in Debug build

### DIFF
--- a/AppleALC/kern_util.cpp
+++ b/AppleALC/kern_util.cpp
@@ -11,7 +11,11 @@
 #include <libkern/libkern.h>
 #include <mach/vm_map.h>
 
+#ifdef DEBUG
+bool debugEnabled = true; 
+#else
 bool debugEnabled = false;
+#endif
 extern vm_map_t kernel_map;
 
 const char *strstr(const char *stack, const char *needle, size_t len) {


### PR DESCRIPTION
Hi,

I've been trying to add ALC892 to AppleALC, but for some reason I cannot load the kext at all with the following message: 

AppleALC: ioutil @ failed to get boot-args property

Couldn't enable the debug flags, because for some reason I don't yet understand, boot arguments are not found. I'm on 10.11.2. Sorry I don't know what other details to give you since I'm a newbie, but I believe it makes sense to have the debugging enabled by default in a Debug build.

Unfortunately I only know how to do it through a macro.

My boot arguments are: "nvda_drv=1 dart=0"

The logs with debugging enabled are:
```
3/8/16 7:49:46.000 PM kernel[0]: AppleALC: (DEBUG) init @ starting AppleALC
3/8/16 7:49:46.000 PM kernel[0]: AppleALC: ioutil @ failed to get boot-args property
3/8/16 7:49:46.000 PM kernel[0]: AppleALC: (DEBUG) init @ no boot arguments available
3/8/16 7:49:46.000 PM kernel[0]: AppleALC: (DEBUG) init @ no boot arguments or found a disabling argument, exiting
3/8/16 7:57:46.000 PM kernel[0]: AppleALC: (DEBUG) init @ starting AppleALC
3/8/16 7:57:46.000 PM kernel[0]: AppleALC: ioutil @ failed to get boot-args property
3/8/16 7:57:46.000 PM kernel[0]: AppleALC: (DEBUG) init @ no boot arguments available
3/8/16 7:57:46.000 PM kernel[0]: AppleALC: (DEBUG) init @ no boot arguments or found a disabling argument, exiting
3/8/16 7:57:50.000 PM kernel[0]: AppleALC: (DEBUG) init @ starting AppleALC
3/8/16 7:57:50.000 PM kernel[0]: AppleALC: ioutil @ failed to get boot-args property
3/8/16 7:57:50.000 PM kernel[0]: AppleALC: (DEBUG) init @ no boot arguments available
3/8/16 7:57:50.000 PM kernel[0]: AppleALC: (DEBUG) init @ no boot arguments or found a disabling argument, exiting
(...)
```