### PR TITLE
Remove redundant logs of AppleHDA and AppleHDAController if debug mode not enabled.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ AppleALC Changelog
 - Added ALC236 layout-id 13 for Lenovo Air 13 Pro by rexx0520
 - Added a workaround for xnu printf limitations
 - Added ALC235 layout-id 11 for Ienovo by soto2080
+- Disabled redundant warnings for non-debug mode by PMheart
 
 #### v1.1.3
 - Fixed ALC889 info.plist min/max kernel


### PR DESCRIPTION
Hi. I think we may remove these kinds of useless complaints in normal cases. As for normal users I suppose they are just harmless and I propose to remove them.